### PR TITLE
fit current timm import, and fix pos_embed shape when using 384

### DIFF
--- a/models/inception_transformer.py
+++ b/models/inception_transformer.py
@@ -29,11 +29,18 @@ import torch.nn.functional as F
 from timm.data import IMAGENET_DEFAULT_MEAN, IMAGENET_DEFAULT_STD, IMAGENET_INCEPTION_MEAN, IMAGENET_INCEPTION_STD
 from timm.models.helpers import build_model_with_cfg, named_apply, adapt_input_conv
 from timm.models.layers import PatchEmbed, Mlp, DropPath, trunc_normal_, lecun_normal_
-from timm.models.registry import register_model
 from torch.nn.init import _calculate_fan_in_and_fan_out
 import math
 import warnings
-from timm.models.layers.helpers import to_2tuple
+try:
+    from timm.models import register_model
+except:
+    from timm.models.registry import register_model
+
+try:
+    from timm.layers.helpers import to_2tuple
+except:
+    from timm.models.layers.helpers import to_2tuple
 
 
 _logger = logging.getLogger(__name__)
@@ -361,7 +368,7 @@ class InceptionTransformer(nn.Module):
         dpr = [x.item() for x in torch.linspace(0, drop_path_rate, depth)]  # stochastic depth decay rule
         
         self.patch_embed = FirstPatchEmbed(in_chans=in_chans, embed_dim=embed_dims[0])
-        self.num_patches1 = num_patches = img_size // 4
+        self.num_patches1 = num_patches = 224 // 4
         self.pos_embed1 = nn.Parameter(torch.zeros(1, num_patches, num_patches, embed_dims[0]))
         self.blocks1 = nn.Sequential(*[
             Block(


### PR DESCRIPTION
Fit current timm `register_model` and `to_2tuple` import, and fix `pos_embed` shape when using 384. When using:
```py
sys.path.append('../pytorch-image-models/')
import torch
from models import inception_transformer
tt = inception_transformer.iformer_small_384(pretrained=True)
```
met 3 errors:
```py
ImportError: cannot import name 'register_model' from 'timm.models.registry'
```
```py
ModuleNotFoundError: No module named 'timm.models.layers.helpers'
```
```py
RuntimeError: Error(s) in loading state_dict for InceptionTransformer:
size mismatch for pos_embed1: copying a param with shape torch.Size([1, 56, 56, 96]) from checkpoint, the shape in current model is torch.Size([1, 96, 96, 96]).
size mismatch for pos_embed2: copying a param with shape torch.Size([1, 28, 28, 192]) from checkpoint, the shape in current model is torch.Size([1, 48, 48, 192]).
size mismatch for pos_embed3: copying a param with shape torch.Size([1, 14, 14, 320]) from checkpoint, the shape in current model is torch.Size([1, 24, 24, 320]).
size mismatch for pos_embed4: copying a param with shape torch.Size([1, 7, 7, 384]) from checkpoint, the shape in current model is torch.Size([1, 12, 12, 384]).
```
- For the first 2, adds a `try except` block fitting current newest timm imports.
- For the 3rd one, I think it should use `224` calculating the first `num_patches` for any input image size.